### PR TITLE
little restructure, and config file

### DIFF
--- a/config_files/2020_05_config.yml
+++ b/config_files/2020_05_config.yml
@@ -1,0 +1,4 @@
+base_url: https://hydrology.nws.noaa.gov/aorc-historic/
+base_directory: /home/jmframe/aorc_historic/data/downloads
+year: 2020
+month: 5

--- a/slurm/download_aorc.slurm
+++ b/slurm/download_aorc.slurm
@@ -7,7 +7,8 @@
 #SBATCH --output=aorc_download_%j.log   # Standard output and error log
 
 module load Anaconda3                    # Load Anaconda module if required
-source activate /home/jmframe/aorc_historic/environment/.conda/envs/aorc_env
+MAIN_DIR="/home/jmframe/aorc_historic/"
+source activate "${MAIN_DIR}environment/.conda/envs/aorc_env"
 
 # Run the download script
-python /home/jmframe/aorc_historic/scripts/download_AORC_by_year_and_month.py
+python "${MAIN_DIR}src/download_AORC_by_year_and_month.py" --config "${MAIN_DIR}config_files/2020_05_config.yml"

--- a/src/download_AORC_by_year_and_month.py
+++ b/src/download_AORC_by_year_and_month.py
@@ -1,10 +1,10 @@
 #!/home/jmframe/aorc_historic/environment/.conda/envs/aorc_env/bin/python3
+import argparse
+import yaml
 import os
 import requests
 from os.path import join, exists
 from os import makedirs
-
-
 
 def download_file(url, directory):
     if not exists(directory):
@@ -35,17 +35,26 @@ def download_region_data(base_url, region_code, year, month, base_directory):
     precip_url = join(base_url, f"AORC_{region_code.upper()}_4km/ABRFC_precip_partition/AORC_APCP_4KM_{region_code.upper()}_{formatted_month}.zip")
     download_file(precip_url, precip_directory)
 
-base_url = 'https://hydrology.nws.noaa.gov/aorc-historic/'
-regions = ['AORC_ABRFC_4km', 'AORC_CBRFC_4km', 'AORC_CNRFC_4km', 'AORC_LMRFC_4km',
-           'AORC_MARFC_4km', 'AORC_MBRFC_4km', 'AORC_NCRFC_4km', 'AORC_NERFC_4km',
-           'AORC_NWRFC_4km', 'AORC_OHRFC_4km', 'AORC_SERFC_4km', 'AORC_WGRFC_4km']
+def main():
+    parser = argparse.ArgumentParser(description="Download AORC data based on configurations from a YAML file.")
+    parser.add_argument('-c', '--config', type=str, required=True, help='Path to the configuration file.')
+    args = parser.parse_args()
 
-base_directory = '/home/jmframe/aorc_historic/data/downloads'
+    with open(args.config, 'r') as ymlfile:
+        cfg = yaml.safe_load(ymlfile)
 
-year = 2020  # Change as needed
-month = 5    # Change as needed
+    base_url = cfg['base_url']
+    base_directory = cfg['base_directory']
+    year = cfg['year']
+    month = cfg['month']
+    
+    regions = ['AORC_ABRFC_4km', 'AORC_CBRFC_4km', 'AORC_CNRFC_4km', 'AORC_LMRFC_4km',
+               'AORC_MARFC_4km', 'AORC_MBRFC_4km', 'AORC_NCRFC_4km', 'AORC_NERFC_4km',
+               'AORC_NWRFC_4km', 'AORC_OHRFC_4km', 'AORC_SERFC_4km', 'AORC_WGRFC_4km']
 
-for region in regions:
-    region_code = region.split('_')[1]
-    download_region_data(base_url, region_code, year, month, base_directory)
-    break
+    for region in regions:
+        region_code = region.split('_')[1]
+        download_region_data(base_url, region_code, year, month, base_directory)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Restructured the directories. So we have now

- src
- slurm
- environment
- config_files

I think this is mostly self explanatory. Config files include the year, month and download directory. e.g.:
```
base_url: https://hydrology.nws.noaa.gov/aorc-historic/
base_directory: /home/jmframe/aorc_historic/data/downloads
year: 2020
month: 5
```
the file 'src/download_AORC_by_year_and_month.py' now reads in the config file for details.